### PR TITLE
:bug: use Figure type that works on earlier plotly versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 dependencies = [
   "plotly",
   "plotly_express",
-  "typing_extensions",
 ]
 
 [project.optional-dependencies]

--- a/src/plotly_football_pitch/pitch_plot.py
+++ b/src/plotly_football_pitch/pitch_plot.py
@@ -1,21 +1,12 @@
 """Create a plotly figure of a football pitch."""
 from typing import Optional
 
-try:
-    from typing import TypeAlias  # type:ignore
-except ImportError:
-    from typing_extensions import TypeAlias
-
 import numpy as np
-import plotly
 import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from plotly_football_pitch.pitch_dimensions import PitchDimensions
-
-
-PlotlyFigure: TypeAlias = plotly.graph_objs._figure.Figure
 
 
 def make_ellipse_arc_svg_path(
@@ -73,7 +64,7 @@ def make_pitch_figure(
     pitch_colour: Optional[str] = None,
     figure_width_pixels: int = 800,
     figure_height_pixels: int = 600,
-) -> PlotlyFigure:
+) -> go.Figure:
     """Create a plotly figure of a football pitch with markings.
 
     Args:
@@ -259,7 +250,7 @@ def make_pitch_figure(
     return fig
 
 
-def add_heatmap(fig: PlotlyFigure, data: np.ndarray) -> PlotlyFigure:
+def add_heatmap(fig: go.Figure, data: np.ndarray) -> go.Figure:
     """Add a heatmap to an existing figure.
 
     Args:


### PR DESCRIPTION
On `plotly==5.1.0` the type alias `PlotlyFigure = plotly.graph_objs._figure.Figure` was raising an attribute error on the `_figure` part. [This SO answer](https://stackoverflow.com/questions/74810332/type-hint-for-output-of-plotly-express) indicated that simply using `plotly.graph_objects.Figure` works in both older and newer versions :tada:.