### PR TITLE
:bug: Add deps so that sphinx docs build does not give warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install -U '.[dev]'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
-          pip install myst_parser sphinx sphinx_rtd_theme
+          python -m pip install -U '.[dev]'
       - name: Sphinx build
         run: |
           sphinx-build docs _build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Python
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install -U '.[dev]'


### PR DESCRIPTION
Dependency errors [here](https://github.com/minimav/plotly-football-pitch/actions/runs/4338087942/jobs/7574528084) caused the documentation to not build correctly. 